### PR TITLE
Térimo de correção de repositórios

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "git.ignoreLimitWarning": true
-}


### PR DESCRIPTION
Devido aos testes para a configuração do typescripts alguns arq e pastas foram gerados em repositórios incorretamente.